### PR TITLE
add basic support for hashcat hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,16 @@ john's different cracking modes, wordlist rules and so on. It is probably a
 good idea to adapt the wordlist and mangling rules to the kind of zone you are
 trying to map.
 
+You can also try to crack NSEC3 records using [hashcat](https://hashcat.net/hashcat/ "hashcat"),
+using hashes converted to a slightly different format:
+
+	n3map-hashcatify example.com.zone example.com.hashcat
+
+The records can then be cracked simply by running `hashcat` on the resulting file:
+
+	hashcat -m 8300 example.com.hashcat
+
+
 
 Installation
 ------------
@@ -157,21 +167,10 @@ can then copy this file to the n3map/ directory.
 cracking patch from this project. There is no need to install it separately,
 just follow the build instructions for JtR-Jumbo.
 
-If you want to crack NSEC3 hashes, you also need to patch and install [John the
-Ripper](http://www.openwall.com/john/)
-Version 1.7.8-jumbo8 or later is required. 
+If you want to crack NSEC3 hashes, you also need [John the Ripper]
+(http://www.openwall.com/john/) vrsion 1.7.8-jumbo8 or later.
 Note that you will need the community-enhanced version of JtR ("jumbo patch"),
-not the normal JtR!
-
-After you unpacked JtR, copy `nsec3_gen_fmt_plug.c` to JtR's src/ directory, and
-compile with `make clean <system>` as usual, e.g.:
-
-	make clean linux-x86-64
-
-Later versions use autoconf, in that case run:
-
-	./configure && make
-
+not the normal JtR! You can also use [hashcat](https://hashcat.net/hashcat/ "hashcat"),
 
 Limitations
 -----------

--- a/README.md
+++ b/README.md
@@ -169,8 +169,9 @@ just follow the build instructions for JtR-Jumbo.
 
 If you want to crack NSEC3 hashes, you also need [John the Ripper](http://www.openwall.com/john/) 
 version 1.7.8-jumbo8 or later. Note that you will need the community-enhanced 
-version of JtR ("jumbo patch"), not the normal JtR! You can also use 
-[hashcat](https://hashcat.net/hashcat/ "hashcat").
+version of JtR ("jumbo patch"), not the normal JtR! 
+
+You can also use [hashcat](https://hashcat.net/hashcat/ "hashcat").
 
 Limitations
 -----------

--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ can then copy this file to the n3map/ directory.
 cracking patch from this project. There is no need to install it separately,
 just follow the build instructions for JtR-Jumbo.
 
-If you want to crack NSEC3 hashes, you also need [John the Ripper]
-(http://www.openwall.com/john/) vrsion 1.7.8-jumbo8 or later.
-Note that you will need the community-enhanced version of JtR ("jumbo patch"),
-not the normal JtR! You can also use [hashcat](https://hashcat.net/hashcat/ "hashcat"),
+If you want to crack NSEC3 hashes, you also need [John the Ripper](http://www.openwall.com/john/) 
+version 1.7.8-jumbo8 or later. Note that you will need the community-enhanced 
+version of JtR ("jumbo patch"), not the normal JtR! You can also use 
+[hashcat](https://hashcat.net/hashcat/ "hashcat"),
 
 Limitations
 -----------

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ just follow the build instructions for JtR-Jumbo.
 If you want to crack NSEC3 hashes, you also need [John the Ripper](http://www.openwall.com/john/) 
 version 1.7.8-jumbo8 or later. Note that you will need the community-enhanced 
 version of JtR ("jumbo patch"), not the normal JtR! You can also use 
-[hashcat](https://hashcat.net/hashcat/ "hashcat"),
+[hashcat](https://hashcat.net/hashcat/ "hashcat").
 
 Limitations
 -----------

--- a/doc/n3map-hashcatify.1
+++ b/doc/n3map-hashcatify.1
@@ -1,0 +1,15 @@
+.TH N3MAP-HASHCATIFY 1 "2017-06-10" "n3map v.0.2.14"
+.SH NAME
+n3map-hashcatify \- convert NSEC3 records to a hashcat-friendly format.
+.SH SYNOPSIS
+.B n3map-hashcatify
+file [outfile]
+.SH DESCRIPTION
+.B n3map-hashcatify 
+reads NSEC3 records from a file, and writes them to standard output in a format
+readable by hashcat. If outfile is specified, the records are written to
+outfile instead of standard output.
+
+.SH "SEE ALSO"
+\fBn3map\fR(1),
+\fBn3map-nsec3-lookup\fR(1)

--- a/doc/n3map-nsec3-lookup.1
+++ b/doc/n3map-nsec3-lookup.1
@@ -30,7 +30,7 @@ This tool could also be used to crack NSEC3 records by passing guesses for
 domain names to standard input. However, this is not recommended since it is in
 no way optimised for performance. 
 If you want to crack NSEC3 records, you should use a tool more suitable to do
-the job, e.g. \fBjohn\fR(8).
+the job, e.g. \fBjohn\fR(8) or hashcat.
 
 .SH EXAMPLES
 .PP
@@ -50,6 +50,7 @@ $ n3map-nsec3-lookup records.nsec3 -o out < names
 .PP
 .SH "SEE ALSO"
 \fBn3map\fR(1),
+\fBn3map-hashcatify\fR(1),
 \fBn3map-johnify\fR(1),
 \fBjohn\fR(8)
 

--- a/doc/n3map.1
+++ b/doc/n3map.1
@@ -243,6 +243,7 @@ nameserver using a different port (5353).
 
 .SH "SEE ALSO"
 \fBn3map-nsec3-lookup\fR(1),
+\fBn3map-hashcatify\fR(1),
 \fBn3map-johnify\fR(1),
 \fBdig(1)\fR
 

--- a/hashcatify.py
+++ b/hashcatify.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+import sys
+import os
+
+from n3map import log
+from n3map import rrfile
+from n3map import util
+from n3map.exception import N3MapError
+
+def usage(argv):
+    sys.stderr.write("usage: " + os.path.basename(argv[0]) + " file [outfile]\n")
+    sys.exit(2)
+
+def main(argv):
+    log.logger = log.Logger()
+    try:
+        if len(argv) < 2:
+            usage(argv)
+        if len(argv) == 3:
+            out = open(argv[2], "wb")
+        else:
+            out = sys.stdout
+
+        records_file = rrfile.open_input_rrfile(argv[1])
+
+        for nsec3 in records_file.nsec3_reader():
+            nsec3_hash = util.str_to_hex(nsec3.hashed_owner)
+            zone = str(nsec3.zone)
+            iterations = "{0:d}".format(nsec3.iterations)
+            salt = util.str_to_hex(nsec3.salt)
+            out.write(":".join((nsec3_hash, "." + zone, salt, iterations)) 
+                    + "\n")
+    except (IOError, N3MapError), e:
+        log.fatal(e)
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main(sys.argv))
+    except KeyboardInterrupt:
+        sys.stderr.write("\nreceived SIGINT, terminating\n")
+        sys.exit(3)
+

--- a/hashcatify.py
+++ b/hashcatify.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import re
 
 from n3map import log
 from n3map import rrfile
@@ -27,6 +28,7 @@ def main(argv):
         for nsec3 in records_file.nsec3_reader():
             nsec3_hash = util.base32_ext_hex_encode(nsec3.hashed_owner).lower()
             zone = str(nsec3.zone)
+            zone = re.sub('\.$', '', zone)
             iterations = "{0:d}".format(nsec3.iterations)
             salt = util.str_to_hex(nsec3.salt)
             out.write(":".join((nsec3_hash, "." + zone, salt, iterations)) 

--- a/hashcatify.py
+++ b/hashcatify.py
@@ -25,7 +25,7 @@ def main(argv):
         records_file = rrfile.open_input_rrfile(argv[1])
 
         for nsec3 in records_file.nsec3_reader():
-            nsec3_hash = util.str_to_hex(nsec3.hashed_owner)
+            nsec3_hash = util.base32_ext_hex_encode(nsec3.hashed_owner).lower()
             zone = str(nsec3.zone)
             iterations = "{0:d}".format(nsec3.iterations)
             salt = util.str_to_hex(nsec3.salt)

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,11 @@ from distutils.core import setup, Extension
 
 shutil.copyfile("map.py", os.path.join("n3map", "n3map"))
 shutil.copyfile("nsec3-lookup.py", os.path.join("n3map", "n3map-nsec3-lookup"))
+shutil.copyfile("hashcatify.py", os.path.join("n3map", "n3map-hashcatify"))
 shutil.copyfile("johnify.py", os.path.join("n3map", "n3map-johnify"))
 
-for mp in ('doc/n3map.1', 'doc/n3map-johnify.1', 'doc/n3map-nsec3-lookup.1'):
+for mp in ('doc/n3map.1', 'doc/n3map-hashcatify.1', 'doc/n3map-johnify.1',
+        'doc/n3map-nsec3-lookup.1'):
     man_in = open(mp, 'rb')
     man_out = gzip.open(mp + '.gz', 'wb')
     man_out.writelines(man_in)
@@ -25,9 +27,10 @@ setup (name = 'n3map',
                     'n3map.tree'],
         ext_modules = [nsec3hashmod],
         scripts = ['n3map/n3map', 'n3map/n3map-nsec3-lookup',
-            'n3map/n3map-johnify'],
+            'n3map/n3map-johnify', 'n3map/n3map-hashcatify'],
         data_files = [('/usr/local/share/man/man1/', ['doc/n3map.1.gz',
-            'doc/n3map-nsec3-lookup.1.gz', 'doc/n3map-johnify.1.gz'])]
+            'doc/n3map-nsec3-lookup.1.gz', 'doc/n3map-johnify.1.gz',
+            'doc/n3map-hashcatify.1.gz'])]
         )
 
 print "cleaning..."
@@ -35,8 +38,10 @@ print "cleaning..."
 try:
     os.remove("n3map/n3map")
     os.remove("n3map/n3map-nsec3-lookup")
+    os.remove("n3map/n3map-hashcatify")
     os.remove("n3map/n3map-johnify")
     os.remove("doc/n3map.1.gz")
+    os.remove("doc/n3map-hashcatify.1.gz")
     os.remove("doc/n3map-johnify.1.gz")
     os.remove("doc/n3map-nsec3-lookup.1.gz")
 except:


### PR DESCRIPTION
Add basic support for hashcat-compatible hashes, which are of the form:

    hash + ":" + '.' + domain +  ":" + salt + ":" . iterations

For example, this hash is for the 'hashcat' hostname:

    7b5n74kq8r441blc2c5qbbat19baj79r:.lvdsiqfj.net:33164473:1  

The hashes can then be cracked using hashcat's mode 8300:

        hashcat -m 8300 [hashes-file]