### PR TITLE
add install_requires; add python_requires, make setup.py handle pytho…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,12 @@ setup (name = 'n3map',
             'n3map/n3map-johnify', 'n3map/n3map-hashcatify'],
         data_files = [('/usr/local/share/man/man1/', ['doc/n3map.1.gz',
             'doc/n3map-nsec3-lookup.1.gz', 'doc/n3map-johnify.1.gz',
-            'doc/n3map-hashcatify.1.gz'])]
+            'doc/n3map-hashcatify.1.gz'])],
+        install_requires = ['dnspython>=1.8'],
+        python_requires = '>=2.6,<3.0'
         )
 
-print "cleaning..."
+print ("cleaning...")
 
 try:
     os.remove("n3map/n3map")


### PR DESCRIPTION
This commit adds `dnspython` dependency into `setup.py` in order to resolve dependencies automatically. Entire install process looks like this:
```bash
pip install .
```

Also it adds requirements for python and syntax compliance of setup.py with python3. Attempt to install this package using python3 now fails with proper description like this:
```
n3map requires Python '>=2.6,<3.0' but the running Python is 3.5.3
```