### PR TITLE
Fall back to TCP in case of truncation

### DIFF
--- a/n3map/query.py
+++ b/n3map/query.py
@@ -8,6 +8,7 @@ import dns.query
 import dns.rcode
 import dns.rdataclass
 import dns.rdatatype
+import dns.flags
 
 from . import name
 from .rrtypes import nsec3
@@ -118,6 +119,8 @@ def dnspython_query(dname, ns_ip, ns_port, rrtype, timeout):
                                payload = 4096)
     r = dns.query.udp(q, ns_ip, port=ns_port, timeout=timeout,
             ignore_unexpected=True)
+    if r.flags & dns.flags.TC:
+        r = dns.query.tcp(q, ns_ip, port=ns_port, timeout=timeout)
 
     return DNSPythonResult(r)
 


### PR DESCRIPTION
Currently, the tool fails in case responses are truncated. Therefore, this commit adds support for falling back to TCP.

`artcom.de` and `defcon.org` are examples of zones that are now walkable with this addition.