### PR TITLE
fix: allow any valid DNS label characters in RR file parser

### DIFF
--- a/n3map/rrtypes/nsec.py
+++ b/n3map/rrtypes/nsec.py
@@ -25,7 +25,7 @@ class NSEC(rr.RR):
         return '\t'.join((super(NSEC, self).__str__(), "NSEC", str(self.next_owner), ' '.join(self.types)))
 
 def parser():
-    p_nsec = re.compile(r'^NSEC\s+(([a-zA-Z0-9\\_*-]+\.|\.)+)((\s+[A-Z0-9]+)*)\s*$')
+    p_nsec = re.compile(r'^NSEC\s+((\S+?\.|\.)+)((\s+[A-Z0-9]+)*)\s*$')
     rr_parse = rr.parser()
     def nsec_from_text(s):
         try:

--- a/n3map/rrtypes/rr.py
+++ b/n3map/rrtypes/rr.py
@@ -16,7 +16,7 @@ class RR(object):
 
 def parser():
     """Returns a parser for a general resource record"""
-    p = re.compile(r'^(([a-zA-Z0-9\\_*-]+\.)+|\.)\s+([0-9]|[1-9][0-9]*)\s+IN\s+(.*)$')
+    p = re.compile(r'^(([^\s.]+\.)+|\.)\s+([0-9]|[1-9][0-9]*)\s+IN\s+(.*)$')
     def rr_from_text(s):
         m = p.match(s)
         try:


### PR DESCRIPTION
The parser regexes for owner and next-owner names only accepted [a-zA-Z0-9\\_*-], but vis.py can output any printable ASCII in labels. This caused --continue to fail with "invalid file format" on zones containing names like //.com.er. (RFC 2181 §11 permits any octet in labels).

Relax both regexes to accept any non-whitespace, non-dot character, matching what the writer can produce and the DNS protocol allows.

Fixes: https://github.com/anonion0/nsec3map/issues/29