### PR TITLE
fix: use raw strings for regex patterns

### DIFF
--- a/n3map/hashcatify.py
+++ b/n3map/hashcatify.py
@@ -27,7 +27,7 @@ def hashcatify_main(argv):
             nsec3_hash = util.base32_ext_hex_encode(nsec3.hashed_owner).lower()
             nsec3_hash = nsec3_hash.decode()
             zone = str(nsec3.zone)
-            zone = re.sub('\.$', '', zone)
+            zone = re.sub(r'\.$', '', zone)
             iterations = "{0:d}".format(nsec3.iterations)
             salt = nsec3.salt.hex()
             out.write(":".join((nsec3_hash, "." + zone, salt, iterations))

--- a/n3map/map.py
+++ b/n3map/map.py
@@ -35,7 +35,7 @@ def _compute_query_interval(n, unit):
     return units[unit]/n
 
 def _query_interval(s):
-    p = re.compile('^(([0-9]\.|[1-9][0-9]*[.]?)[0-9]*)/([smh])$')
+    p = re.compile(r'^(([0-9]\.|[1-9][0-9]*[.]?)[0-9]*)/([smh])$')
     m = p.match(s)
     if m is None:
         raise ValueError

--- a/n3map/rrfile.py
+++ b/n3map/rrfile.py
@@ -97,7 +97,7 @@ class RRFileStream(object):
     def nsec3_reader(self):
         log.info("reading NSEC3 RRs from ", str(self.f.name))
         self.seek(0)
-        p_counter = re.compile("^;;;; label_counter\s*=\s*0x([0-9a-fA-F]+)")
+        p_counter = re.compile(r"^;;;; label_counter\s*=\s*0x([0-9a-fA-F]+)")
         p_ignore = re.compile(_comment_pattern)
         nsec3_parse = rrtypes.nsec3.parser()
         for i, line in enumerate(self.f, start=1):


### PR DESCRIPTION
Python 3.12+ warns on invalid escape sequences like \. and \s in regular strings. Use raw strings (r'...') to silence SyntaxWarnings.